### PR TITLE
Trim text from WS Crafting query

### DIFF
--- a/HaselTweaks/Windows/MJICraftScheduleSettingSearchBar.cs
+++ b/HaselTweaks/Windows/MJICraftScheduleSettingSearchBar.cs
@@ -91,7 +91,7 @@ public unsafe class MJICraftScheduleSettingSearchBar : Window
                 }
             }
 
-            var result = entries.FuzzyMatch(Query.ToLower(), value => value.ItemName).FirstOrDefault();
+            var result = entries.FuzzyMatch(Query.ToLower().Trim(), value => value.ItemName).FirstOrDefault();
             if (result != default)
             {
                 var index = result.Value.Index;


### PR DESCRIPTION
Trim the text query when doing the fuzzy search so that copying and pasting text like "Eggs " returns results from "eggs".

A small QoL feature that was bugging the hell out of me when copying from a workshop discord bot is that it always copied with a extra space. Trimming the surrounding whitespace from the user input should yield the same results.