### PR TITLE
Improve performance of DtrBusy

### DIFF
--- a/HaselTweaks/Tweaks/DTR.cs
+++ b/HaselTweaks/Tweaks/DTR.cs
@@ -47,6 +47,14 @@ public unsafe partial class DTR(
 
         DtrBusy = DtrBar.Get("[HaselTweaks] Busy");
         DtrBusy.Tooltip = "HaselTweaks";
+        DtrBusy.Text = new SeStringBuilder()
+            .PushColorType(1)
+            .PushEdgeColorType(16)
+            .Append(ExcelService.GetRow<OnlineStatus>(12)?.Name.RawData.ToArray() ?? Encoding.UTF8.GetBytes("Busy"))
+            .PopEdgeColorType()
+            .PopColorType()
+            .ToSeString()
+            .ToDalamudString();
 
         DtrInstance.Shown = false;
         DtrFPS.Shown = false;
@@ -128,15 +136,6 @@ public unsafe partial class DTR(
     {
         if (DtrBusy == null)
             return;
-
-        DtrBusy.Text = new SeStringBuilder()
-            .PushColorType(1)
-            .PushEdgeColorType(16)
-            .Append(ExcelService.GetRow<OnlineStatus>(12)?.Name.RawData.ToArray() ?? Encoding.UTF8.GetBytes("Busy"))
-            .PopEdgeColorType()
-            .PopColorType()
-            .ToSeString()
-            .ToDalamudString();
 
         DtrBusy.Shown = ClientState.IsLoggedIn && ClientState.LocalPlayer?.OnlineStatus.Id == 12;
     }


### PR DESCRIPTION
Currently `DtrBusy` is surprisingly heavy in terms of framework time since it's building an `SeString` and doing an Excel lookup each frame. However since the string is actually static we can just build it once and set its visibility each update. This reduces framework time of `DTR.OnFrameworkUpdate` from around 0.0520ms to 0.0025ms on my machine.