### PR TITLE
allow free trial users to use /reloadui

### DIFF
--- a/HaselTweaks/Tweaks/Commands.cs
+++ b/HaselTweaks/Tweaks/Commands.cs
@@ -266,7 +266,8 @@ public unsafe partial class Commands : ConfigurableTweak<CommandsConfiguration>
             ConditionFlag.Jumping,
             ConditionFlag.Mounted,
             ConditionFlag.InFlight,
-            ConditionFlag.UsingFashionAccessory))
+            ConditionFlag.UsingFashionAccessory,
+            ConditionFlag.OnFreeTrial))
         {
             Chat.PrintError(_textService.GetLogMessage(10775));
             return;


### PR DESCRIPTION
Currently, `/reloadui` doesn't work while on a free trial character due to Free Trial being a condition always applied to the character (for whatever functional reason). Adding this condition to the list of allowed conditions makes it work as intended.