### PR TITLE
Enable Glamour Dresser Nav Keys when Mirage Plate is focused

### DIFF
--- a/HaselTweaks/Tweaks/GlamourDresserKeyboardNavigation.cs
+++ b/HaselTweaks/Tweaks/GlamourDresserKeyboardNavigation.cs
@@ -33,8 +33,11 @@ public unsafe partial class GlamourDresserKeyboardNavigation : Tweak
         if (!TryGetAddon<AddonMiragePrismPrismBox>((ushort)agent->GetAddonId(), out var addon))
             return;
 
+        if (!TryGetAddon<AgentMiragePrismMiragePlate>((ushort)AgentMiragePrismMiragePlate.Instance()->GetAddonId(), out var mirageplateaddon))
+            return;
+
         var unitManager = RaptureAtkUnitManager.Instance();
-        if (unitManager == null || unitManager->FocusedAddon != addon)
+        if (unitManager == null || (unitManager->FocusedAddon != addon && unitManager->FocusedAddon != mirageplateaddon))
             return;
 
         EnsureVisibleItemsAreLoaded(agent);


### PR DESCRIPTION
Will preface this that this change will disable the functionality of the tweak if the Glamour Plate Creation window is not displayed. I was unsure if there was really any use for the tweak outside of this use-case.

This change will allow the user to continue to use the navigation keys if the MiragePlate addon is focused, which enables the ability to rotate/zoom/pan the character viewport while changing the active item selection.
Currently you have to juggle between them each time which is an unnecessary hassle

https://github.com/user-attachments/assets/7e739d41-3c2f-4522-8041-5ce7fc7e45a2

