### PR TITLE
Add commas to EXP Bar

### DIFF
--- a/HaselTweaks/Tweaks/EnhancedExpBar.cs
+++ b/HaselTweaks/Tweaks/EnhancedExpBar.cs
@@ -126,7 +126,7 @@ public unsafe partial class EnhancedExpBar : ConfigurableTweak<EnhancedExpBarCon
         var rank = buddy.Rank > 20 ? 20 : buddy.Rank;
         var level = rank.ToString().Aggregate("", (str, chr) => str + (char)(SeIconChar.Number0 + byte.Parse(chr.ToString())));
         var requiredExperience = buddyRank.ExpRequired;
-        var xpText = requiredExperience == 0 ? "" : $"   {buddy.CurrentXP}/{requiredExperience}";
+        var xpText = requiredExperience == 0 ? "" : $"   {buddy.CurrentXP:N0}/{requiredExperience:N0}";
 
         SetText($"{classJob.Abbreviation}  {levelLabel} {level}{xpText}");
         SetExperience((int)buddy.CurrentXP, (int)requiredExperience);
@@ -149,7 +149,7 @@ public unsafe partial class EnhancedExpBar : ConfigurableTweak<EnhancedExpBarCon
         var star = currentRank > claimedRank ? '*' : ' ';
         var requiredExperience = pvpSeriesLevel.ExpToNext;
 
-        SetText($"{classJob.Abbreviation}  {levelLabel} {level}{star}   {pvpProfile->SeriesExperience}/{requiredExperience}");
+        SetText($"{classJob.Abbreviation}  {levelLabel} {level}{star}   {pvpProfile->SeriesExperience:N0}/{requiredExperience:N0}");
         SetExperience(pvpProfile->SeriesExperience, requiredExperience);
 
         if (!_config.DisableColorChanges)
@@ -172,8 +172,8 @@ public unsafe partial class EnhancedExpBar : ConfigurableTweak<EnhancedExpBarCon
         var level = mjiManager->IslandState.CurrentRank.ToString().Aggregate("", (str, chr) => str + (char)(SeIconChar.Number0 + byte.Parse(chr.ToString())));
         var requiredExperience = mjiRank.ExpToNext;
 
-        var expStr = mjiManager->IslandState.CurrentXP.ToString();
-        var reqExpStr = requiredExperience.ToString();
+        var expStr = mjiManager->IslandState.CurrentXP.ToString("#,##0");
+        var reqExpStr = requiredExperience.ToString("#,##0");
         if (requiredExperience == 0)
             expStr = reqExpStr = "--";
 


### PR DESCRIPTION
Adjusts the Enhanced EXP bar to behave more like the vanilla one

Before:
<img width="556" height="81" alt="image" src="https://github.com/user-attachments/assets/6d508f07-37e7-45c8-a8df-c3a995ec30e6" />

After:
<img width="568" height="84" alt="image" src="https://github.com/user-attachments/assets/ef7674df-0998-48b2-99b5-ae30373487c0" />

System culture should take priority for the separators with this implementation, but I haven't tested this without the associated language pack. Just means it will be following the runtime environment rather than the client language setting